### PR TITLE
remove deprecated dependency level. and make some test flavor optional

### DIFF
--- a/create-projects/create-gradle-project.sh
+++ b/create-projects/create-gradle-project.sh
@@ -35,11 +35,14 @@ ext {
 }
 
 dependencies {
-    testImplementation \"org.mockito:mockito-junit-jupiter:\${mockitoVersion}\"
     testImplementation \"org.junit.jupiter:junit-jupiter-api:\${junitVersion}\"
+    // pick your desired test flavors
+    /*
+    testImplementation \"org.junit.jupiter:junit-jupiter-params:\${junitVersion}\"
+    testImplementation \"org.assertj:assertj-core:\${assertjVersion}\"
+    testImplementation \"org.mockito:mockito-junit-jupiter:\${mockitoVersion}\"
+    */
     testRuntimeOnly \"org.junit.jupiter:junit-jupiter-engine:\${junitVersion}\"
-    testCompile \"org.junit.jupiter:junit-jupiter-params:\${junitVersion}\"
-    testCompile \"org.assertj:assertj-core:\${assertjVersion}\"
 }
 " > $PROJECT_NAME/build.gradle
 


### PR DESCRIPTION
Because we don't always need mojito, assertionj, parameterized test(well, maybe this one is somehow must), I left the choices to users.

And adapt new dependency level (testImplementation, testRuntimeOnly).